### PR TITLE
Fix message text color

### DIFF
--- a/Sources/Snackbar/internal/SnackbarMessageView.swift
+++ b/Sources/Snackbar/internal/SnackbarMessageView.swift
@@ -32,7 +32,7 @@ final class SnackbarMessageView: UIView {
         // Mesagge
         let messageLabel = UILabel()
         messageLabel.attributedText = message.messageAttributedString
-        messageLabel.textColor = .white
+        messageLabel.textColor = message.textColor
         messageLabel.font = .systemFont(ofSize: 14)
         messageLabel.numberOfLines = 2
         messageLabel.isUserInteractionEnabled = false


### PR DESCRIPTION
Fixed a problem that message text color keeps being white even you specify the color for SnackbarMessage object.